### PR TITLE
分割したファイルのインポート方法の修正

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,13 +1,6 @@
+from .route.fib import fib
 from flask import Flask, jsonify
-import os
-from dotenv import load_dotenv
-load_dotenv()
 
-# 開発環境、テスト、本番環境でfibを読み込むのに必要な記述が異なるため
-if os.environ['ENV'] == 'development':
-  from route.fib import fib
-else:
-  from app.route.fib import fib
 app = Flask(__name__)
 
 app.register_blueprint(fib)


### PR DESCRIPTION
## 完了条件
- 開発環境、テスト環境、本番環境において同じコードでfib.pyをインポートできている
- 環境変数を用いずにfib.pyをインポートできている

## 行ったこと
- モジュールのインポート順の変更
- モジュールのインポートの記述の変更

## 行わなかったこと
- テストの追加

## テスト観点
- ローカルでの挙動の確認
- pytest -v --cov --cov-report=term-missing でテストが通ることの確認

## キャプチャ

## 注意点
- 別のユーザでコミットしてしまったため、強制プッシュを行っている
- 本番環境で問題が起きた場合、[このコミット](https://github.com/mono-glyceride/mathematics_api/pull/15/commits/03939a6a78ce474a272c355ccc5f34b0eecb56ae)のrevertで修正が可能
- python-dotenv など環境変数周りのファイルで使わなくなったものもあるが、削除していない
    - 問題が起きた場合に迅速に元の状態に戻せる
    - 環境変数を今後も使う可能性がある
    - 存在することによって悪影響が生じるものではない

## 関連URL
バグが発生したきっかけのPR
- https://github.com/mono-glyceride/mathematics_api/pull/8
参考
- https://teratail.com/questions/254369
