### PR TITLE
Fix/revert loading split files

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,6 +1,13 @@
-from .route.fib import fib
 from flask import Flask, jsonify
+import os
+from dotenv import load_dotenv
+load_dotenv()
 
+# 開発環境、テスト、本番環境でfibを読み込むのに必要な記述が異なるため
+if os.environ['ENV'] == 'development':
+  from route.fib import fib
+else:
+  from app.route.fib import fib
 app = Flask(__name__)
 
 app.register_blueprint(fib)


### PR DESCRIPTION
## 完了条件
- docker-compose down 後に再度docker-compose up を行った時、正常にコンテナが立ち上がる
- 以下のバグが修正されている
```$ docker-compose up   
Starting app ... done
Attaching to app
app    | Usage: flask run [OPTIONS]
app    | Try 'flask run --help' for help.
app    | 
app    | Error: While importing 'app', an ImportError was raised:
app    | 
app    | Traceback (most recent call last):
app    |   File "/usr/local/lib/python3.11/site-packages/flask/cli.py", line 218, in locate_app
app    |     __import__(module_name)
app    |   File "/app/app/app.py", line 1, in <module>
app    |     from .route.fib import fib
app    | ImportError: attempted relative import with no known parent package
app    | 
app exited with code 2
```


## 行ったこと
- fix/loading_split_filesで行われた全てのコミットのrevert

## 行わなかったこと
- テストの追加

## テスト観点
- ローカルでの挙動の確認
- pytest -v --cov --cov-report=term-missing でテストが通ることの確認

## キャプチャ

## 注意点
- 一つのコミットをrevertするだけでfix/loading_split_filesブランチの影響は打ち消せるものの、一応当該ブランチの全てのコミットをrevertした

## 関連URL
バグが発生したきっかけのPR
- https://github.com/mono-glyceride/mathematics_api/pull/15
参考
- https://teratail.com/questions/254369
